### PR TITLE
Add .DS_store to .gitignore to prevent macOS system files from being …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,5 @@ src/.streamlit/secrets.toml
 
 # Codespace
 .devcontainer/
+
+.DS_store


### PR DESCRIPTION
…tracked